### PR TITLE
KG - Remove Unused Gemfile.lock Gem

### DIFF
--- a/bosch-target-chart/Gemfile.lock
+++ b/bosch-target-chart/Gemfile.lock
@@ -206,8 +206,6 @@ GEM
     turbolinks-source (5.1.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    uglifier (4.1.5)
-      execjs (>= 0.3.0, < 3)
     web-console (3.5.1)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -244,7 +242,6 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)
   tzinfo-data
-  uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
 
 BUNDLED WITH


### PR DESCRIPTION
The gem was already removed from `Gemfile` but for some reason had not been removed from `Gemfile.lock`