### PR TITLE
KG - Replace 'haml' Gem with 'haml-rails' Gem

### DIFF
--- a/bosch-target-chart/Gemfile
+++ b/bosch-target-chart/Gemfile
@@ -8,7 +8,7 @@ end
 gem 'bootstrap', '~> 4.0.0'
 gem 'coffee-rails', '~> 4.2' # Use CoffeeScript for .coffee assets and views
 gem 'devise' # Used for login authentication
-gem 'haml' # Use HAML for .haml views
+gem 'haml-rails' # Use HAML for .haml views
 gem 'jbuilder', '~> 2.5' # Build JSON APIs with ease
 gem 'jquery-rails'
 gem 'mysql2' # Use MySQL2 for the database

--- a/bosch-target-chart/Gemfile.lock
+++ b/bosch-target-chart/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
       dotenv (= 2.2.1)
       railties (>= 3.2, < 5.2)
     erubi (1.7.0)
+    erubis (2.7.0)
     execjs (2.7.0)
     factory_bot (4.8.2)
       activesupport (>= 3.0.0)
@@ -98,6 +99,17 @@ GEM
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt
+    haml-rails (1.0.0)
+      actionpack (>= 4.0.1)
+      activesupport (>= 4.0.1)
+      haml (>= 4.0.6, < 6.0)
+      html2haml (>= 1.0.1)
+      railties (>= 4.0.1)
+    html2haml (2.2.0)
+      erubis (~> 2.7.0)
+      haml (>= 4.0, < 6)
+      nokogiri (>= 1.6.0)
+      ruby_parser (~> 3.5)
     i18n (0.9.3)
       concurrent-ruby (~> 1.0)
     jbuilder (2.7.0)
@@ -191,6 +203,8 @@ GEM
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
     ruby_dep (1.5.0)
+    ruby_parser (3.11.0)
+      sexp_processor (~> 4.9)
     sass (3.5.5)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -202,6 +216,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sexp_processor (4.10.1)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
     spring (2.0.2)
@@ -250,7 +265,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
-  haml
+  haml-rails
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)


### PR DESCRIPTION
The major difference is `haml-rails` makes the rails generator auto-use `.html.haml` files rather than `.html.erb`