### PR TITLE
KG - Fix Broken User Model Spec

### DIFF
--- a/bosch-target-chart/config/environments/test.rb
+++ b/bosch-target-chart/config/environments/test.rb
@@ -34,6 +34,9 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  # Default URL to localhost
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 


### PR DESCRIPTION
Completes #71 

Needed to add mailer configuration host to the `test.rb` environment file. Devise was trying to send emails upon user creation which failed because there was no host for the emails.