### PR TITLE
KG - DatabaseCleaner Strategy Fixing Broken Specs

### DIFF
--- a/bosch-target-chart/spec/support/database_cleaner.rb
+++ b/bosch-target-chart/spec/support/database_cleaner.rb
@@ -5,7 +5,7 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     # Use the truncation strategy for tests
-    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.strategy = :truncation
     # Truncate tables before the suite to clear all data
     DatabaseCleaner.clean_with(:truncation)
   end


### PR DESCRIPTION
#103

The `transaction` method was causing spec failures when running the suite as a whole. Changing it to `truncation` seems to fix the issue.