### PR TITLE
KG - Fixing Feature Specs and Fixing Targets Table Responsiveness

### DIFF
--- a/bosch-target-chart/app/views/layouts/application.html.haml
+++ b/bosch-target-chart/app/views/layouts/application.html.haml
@@ -4,6 +4,7 @@
     %title
       = t(:site_header)
     = csrf_meta_tags
+    %meta{ name: 'viewport', content: 'width=device-width,initial-scale=1' }
     = stylesheet_link_tag 'application'
     = javascript_include_tag 'application'
   %body

--- a/bosch-target-chart/app/views/layouts/home.html.haml
+++ b/bosch-target-chart/app/views/layouts/home.html.haml
@@ -4,6 +4,7 @@
     %title
       = t(:site_header)
     = csrf_meta_tags
+    %meta{ name: 'viewport', content: 'width=device-width,initial-scale=1' }
     = stylesheet_link_tag 'application'
     = javascript_include_tag 'application'
   %body

--- a/bosch-target-chart/app/views/targets/_table.html.haml
+++ b/bosch-target-chart/app/views/targets/_table.html.haml
@@ -8,17 +8,17 @@
     %table.table.table-bordered.table-sm#targetsTable
       %thead.bg-secondary.text-white.text-center
         %tr.d-flex
-          %th.col-4.col-md-2
+          %th.col-4.col-md-2.d-flex.justify-content-center
             = t(:targets)[:table][:name]
-          %th.col-4.col-md-2
+          %th.col-4.col-md-2.d-flex.justify-content-center
             = t(:targets)[:table][:category]
-          %th.col-md-2.d-none.d-md-table-cell
+          %th.col-md-2.d-none.d-md-flex.justify-content-center
             = t(:targets)[:table][:unit]
-          %th.col-md-1.d-none.d-md-table-cell
+          %th.col-md-1.d-none.d-md-flex.justify-content-center
             = t(:targets)[:table][:update_frequency]
-          %th.col-4.col-md-3
+          %th.col-4.col-md-3.d-flex.justify-content-center
             = t(:targets)[:table][:indicators]
-          %th.col-md-2.d-none.d-md-table-cell
+          %th.col-md-2.d-none.d-md-flex.justify-content-center
             = t(:targets)[:table][:actions]
       %body
         - department.targets.eager_load(:category).each do |target|

--- a/bosch-target-chart/spec/features/user_edits_target_spec.rb
+++ b/bosch-target-chart/spec/features/user_edits_target_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe "User edits a target", js: true do
   it 'should update unit' do
     visit department_path(@department)
 
+    execute_script("$('.d-none').removeClass('d-none')")
+
     find("a[data-original-title='#{I18n.t(:targets)[:fields][:unit]}']").click
     fill_in 'target_unit', with: 'EuroDollars'
     find('button[type=submit]').click
@@ -52,6 +54,8 @@ RSpec.describe "User edits a target", js: true do
   it 'should update update frequency' do
     visit department_path(@department)
 
+    execute_script("$('.d-none').removeClass('d-none')")
+    
     find("a[data-original-title='#{I18n.t(:targets)[:fields][:update_frequency][:field]}']").click
     frequency = I18n.t(:targets)[:fields][:update_frequency][:monthly]
     select frequency, from: 'target_update_frequency'


### PR DESCRIPTION
Finishes #98 

I discovered that adding the meta tag fixes the table's responsiveness on Chrome mobile.

Making the `th`s use `display: flex` makes the view consistent in the Capybara Webkit browser. 

Before, the `th`s would show but not the `td`s. Interestingly enough, Capybara Webkit's selenium driver refuses to not use the mobile display, so I had to use a script to force the hidden columns to show for our specs. I could not find another fix for this in their documentation.