### PR TITLE
SAW - Moved compare_to_value

### DIFF
--- a/bosch-target-chart/app/models/target.rb
+++ b/bosch-target-chart/app/models/target.rb
@@ -6,11 +6,15 @@ class Target < ApplicationRecord
   has_and_belongs_to_many :charts
 
   validates :name, :department_id, :category_id, :unit, :unit_type, :update_frequency, presence: true
+  validates :compare_to_value, presence: true, unless: :is_qualitative?
   validates :year, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
   UNIT_TYPES = [
     I18n.t(:targets)[:fields][:unit_type][:numerical],
-    I18n.t(:targets)[:fields][:unit_type][:percentage],
     I18n.t(:targets)[:fields][:unit_type][:qualitative],
   ]
+
+  def is_qualitative?
+    self.unit_type == Target::UNIT_TYPES[1]
+  end
 end

--- a/bosch-target-chart/db/migrate/20180309002705_remove_compare_to_value_from_indicators.rb
+++ b/bosch-target-chart/db/migrate/20180309002705_remove_compare_to_value_from_indicators.rb
@@ -1,0 +1,5 @@
+class RemoveCompareToValueFromIndicators < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :indicators, :compare_to_value
+  end
+end

--- a/bosch-target-chart/db/migrate/20180309002740_add_compare_to_value_to_targets.rb
+++ b/bosch-target-chart/db/migrate/20180309002740_add_compare_to_value_to_targets.rb
@@ -1,0 +1,5 @@
+class AddCompareToValueToTargets < ActiveRecord::Migration[5.1]
+  def change
+    add_column :targets, :compare_to_value, :decimal, precision: 22, scale: 10
+  end
+end

--- a/bosch-target-chart/db/schema.rb
+++ b/bosch-target-chart/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180303035735) do
+ActiveRecord::Schema.define(version: 20180309002740) do
 
   create_table "categories", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name"
@@ -46,7 +46,6 @@ ActiveRecord::Schema.define(version: 20180303035735) do
     t.bigint "target_id"
     t.string "name"
     t.decimal "value", precision: 22, scale: 10
-    t.decimal "compare_to_value", precision: 22, scale: 10
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["target_id"], name: "index_indicators_on_target_id"
@@ -63,6 +62,7 @@ ActiveRecord::Schema.define(version: 20180303035735) do
     t.datetime "updated_at", null: false
     t.integer "year"
     t.string "unit_type"
+    t.decimal "compare_to_value", precision: 22, scale: 10
     t.index ["category_id"], name: "index_targets_on_category_id"
     t.index ["department_id"], name: "index_targets_on_department_id"
   end

--- a/bosch-target-chart/spec/factories/target.rb
+++ b/bosch-target-chart/spec/factories/target.rb
@@ -4,9 +4,15 @@ FactoryBot.define do
     department_id     { FactoryBot.create(:department).id }
     category_id       { FactoryBot.create(:category).id }
     unit              { Faker::Lorem.word }
-    unit_type         { Target::UNIT_TYPES.sample }
+    unit_type         { Target::UNIT_TYPES[1] }
     update_frequency  { [I18n.t(:targets)[:fields][:update_frequency][:monthly], I18n.t(:targets)[:fields][:update_frequency][:yearly]].sample }
     comments          { Faker::Lorem.sentence }
     year              { 1970 + Random.rand(100) }
+
+    trait :numerical do
+      unit_type { Target::UNIT_TYPES[0] }
+      compare_to_value { Random.rand(100) }
+    end
+
   end
 end

--- a/bosch-target-chart/spec/models/target_spec.rb
+++ b/bosch-target-chart/spec/models/target_spec.rb
@@ -1,19 +1,32 @@
 require 'rails_helper'
 
 RSpec.describe Target, type: :model do
-  it { is_expected.to belong_to(:department) }
-  it { is_expected.to belong_to(:category) }
 
-  it { is_expected.to have_many(:indicators) }
+  describe 'validations' do
+    it { is_expected.to belong_to(:department) }
+    it { is_expected.to belong_to(:category) }
 
-  it { is_expected.to validate_presence_of(:name) }
-  it { is_expected.to validate_presence_of(:department_id) }
-  it { is_expected.to validate_presence_of(:category_id) }
-  it { is_expected.to validate_presence_of(:unit) }
-  it { is_expected.to validate_presence_of(:unit_type) }
-  it { is_expected.to validate_presence_of(:update_frequency) }
+    it { is_expected.to have_many(:indicators) }
 
-  it { is_expected.to validate_presence_of(:year) }
-  it { is_expected.to validate_numericality_of(:year).only_integer }
-  it { is_expected.to validate_numericality_of(:year).is_greater_than_or_equal_to(0) }
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:department_id) }
+    it { is_expected.to validate_presence_of(:category_id) }
+    it { is_expected.to validate_presence_of(:unit) }
+    it { is_expected.to validate_presence_of(:unit_type) }
+    it { is_expected.to validate_presence_of(:update_frequency) }
+
+    it { is_expected.to validate_presence_of(:year) }
+    it { is_expected.to validate_numericality_of(:year).only_integer }
+    it { is_expected.to validate_numericality_of(:year).is_greater_than_or_equal_to(0) }
+
+    context 'is numerical' do
+      before { allow(subject).to receive(:is_qualitative?).and_return(false) }
+      it { is_expected.to validate_presence_of(:compare_to_value) }
+    end
+
+    context 'is qualitative' do
+      before { allow(subject).to receive(:is_qualitative?).and_return(true) }
+      it { is_expected.to_not validate_presence_of(:compare_to_value) }
+    end
+  end
 end


### PR DESCRIPTION
Issue #106 

I moved `compare_to_value` from Indicators to Targets, and I also removed the percentage unit_type since it wasn't in use and it didn't serve a purpose with the `unit` attribute