### PR TITLE
KG - Initialize Edit Popovers When Re-rendering Targets Table

### DIFF
--- a/bosch-target-chart/app/assets/javascripts/departments.coffee
+++ b/bosch-target-chart/app/assets/javascripts/departments.coffee
@@ -1,15 +1,6 @@
 $ ->
-  $("[data-toggle='popover']").popover(
-    template: "<div class='popover' role='tooltip'>
-                <div class='arrow'></div>
-                <h3 class='popover-header'></h3>
-                <div class='popover-body'></div>
-                <div class='popover-footer'>
-                  <input class='btn btn-sm btn-primary pull-right' value='#{I18n.actions.submit}' type='submit' form='updateForm' />
-                  <div class='clearfix'></div>
-                </div>
-              </div>"
-  )
+  
+  initializePopovers()
   
   # Credit to https://stackoverflow.com/a/9440580
   # for binding events to allow clicks / focuses correctly
@@ -43,3 +34,16 @@ $ ->
       $.ajax
         type: 'delete'
         url: "/targets/#{target_id}.js"
+
+(exports ? this).initializePopovers = () ->
+  $("[data-toggle='popover']").popover(
+    template: "<div class='popover' role='tooltip'>
+                <div class='arrow'></div>
+                <h3 class='popover-header'></h3>
+                <div class='popover-body'></div>
+                <div class='popover-footer'>
+                  <input class='btn btn-sm btn-primary pull-right' value='#{I18n.actions.submit}' type='submit' form='updateForm' />
+                  <div class='clearfix'></div>
+                </div>
+              </div>"
+  )

--- a/bosch-target-chart/app/views/targets/create.js.coffee
+++ b/bosch-target-chart/app/views/targets/create.js.coffee
@@ -2,5 +2,6 @@
 $('#formErrors').html("<%= j render 'shared/form_errors', errors: @errors %>")
 <% else %>
 $('#targetsContainer').replaceWith("<%= j render 'targets/table', department: @department, year: @year %>")
+initializePopovers()
 $('#modalContainer').modal('hide')
 <% end %>

--- a/bosch-target-chart/app/views/targets/destroy.js.coffee
+++ b/bosch-target-chart/app/views/targets/destroy.js.coffee
@@ -1,1 +1,2 @@
 $('#targetsContainer').replaceWith("<%= j render 'targets/table', department: @department, year: @year %>")
+initializePopovers()


### PR DESCRIPTION
See #122 

When creating or destroying a target, the edit popovers were not correctly reinitialized which caused their submit buttons not to show (See screenshot). This was easy to fix by re-initializing them after rendering the targets table.

### Before: After creating a target, the buttons are now gone
<img width="1119" alt="image" src="https://user-images.githubusercontent.com/12898988/37262348-f7a5d23a-2578-11e8-970f-a6adda2121f6.png">

### Specs passing
<img width="676" alt="image" src="https://user-images.githubusercontent.com/12898988/37263484-d361eec6-257e-11e8-80ea-3debe989c578.png">
