### PR TITLE
JAG - Removed an overriding flag to fix color

### DIFF
--- a/bosch-target-chart/app/assets/stylesheets/layout.scss
+++ b/bosch-target-chart/app/assets/stylesheets/layout.scss
@@ -40,7 +40,7 @@ html {
             width: 170px;
           }
         }
-          
+
         .nav-link {
           font-size: 1.5rem;
           font-weight: 300;
@@ -101,7 +101,7 @@ html {
 
     a:not(.btn) {
       text-decoration: none !important;
-      color: $theme_primary !important;
+      color: $theme_primary;
       font-weight: 200;
     }
 


### PR DESCRIPTION
An !imporant flag was overriding the text-danger contextual class that we had assigned to the logout link.