### PR TITLE
KG - Tooltip Bug

### DIFF
--- a/bosch-target-chart/app/assets/javascripts/dashboard.coffee
+++ b/bosch-target-chart/app/assets/javascripts/dashboard.coffee
@@ -15,10 +15,12 @@ $ ->
       $('#targetsSidebar').css('top', '')
 
 showSidebar = () ->
+  $('#openTargetsSidebarButton').tooltip('hide')
   $('#openTargetsSidebarButton').fadeOut 'fast', ->
     $('#targetsSidebarPanel').animate {right: '0%'}, 250
 
 hideSidebar = () ->
+  $('#closeTargetsSidebarButton').tooltip('hide')
   $('#targetsSidebarPanel').animate {right: '100%'}, 250, ->
     $('#openTargetsSidebarButton').fadeIn 'fast'
 


### PR DESCRIPTION
Issue #192 

When opening/closing the sidebar the buttons would disappear but the tooltips would stay in some browsers. This manually hides them so that doesn't happen.