### PR TITLE
KG - Category Blank Icon URL in Production

### DIFF
--- a/bosch-target-chart/app/models/category.rb
+++ b/bosch-target-chart/app/models/category.rb
@@ -1,6 +1,6 @@
 class Category < ApplicationRecord
   has_many :targets
-  has_attached_file :icon, default_url: ActionController::Base.helpers.asset_path("categories/blank_category_icon.png")
+  has_attached_file :icon, default_url: "categories/blank_category_icon.png"
 
   COLOR_HEX_VALUES_HASH = HashWithIndifferentAccess.new(YAML.load_file("#{Rails.root}/config/colors.yml"))[:chart_colors]
 


### PR DESCRIPTION
When we precompile assets in Production, the URL used before would not find the `public/assets` folder where assets are moved to. Using just this URL seems to fix the issue.