### PR TITLE
KG - Production Mailer Emails

### DIFF
--- a/bosch-target-chart/config/environments/production.rb
+++ b/bosch-target-chart/config/environments/production.rb
@@ -61,6 +61,8 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "bosch-target-chart_#{Rails.env}"
   config.action_mailer.perform_caching = false
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true 
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
Emails were not sending on the production server. Apparently you need to turn this on in order for them to send.