### PR TITLE
SAW - Category select options all have the same background/text color

### DIFF
--- a/bosch-target-chart/app/assets/stylesheets/categories.scss
+++ b/bosch-target-chart/app/assets/stylesheets/categories.scss
@@ -27,6 +27,13 @@
   }
 }
 
+#category_color {
+  option {
+    background: white;
+    color: black;
+  }
+}
+
 .icon-input-row {
   justify-content: space-between;
 


### PR DESCRIPTION
Issue #178 
---
The color select options all have the same background and text color in Firefox (this was not an issue in Chrome since Chrome's select option colors aren't editable). Here's a screenshot of what it looks like now in Firefox:
![image](https://user-images.githubusercontent.com/19152930/38785702-82945af0-40f0-11e8-949f-4a0bf7cbbc23.png)

All specs passing (although this was only a cosmetic change)
![image](https://user-images.githubusercontent.com/19152930/38785729-c3e5a82e-40f0-11e8-9b36-ef76e4559a8c.png)

