### PR TITLE
SAW - Fixed icon preview size

### DIFF
--- a/bosch-target-chart/app/assets/stylesheets/categories.scss
+++ b/bosch-target-chart/app/assets/stylesheets/categories.scss
@@ -37,7 +37,10 @@
 .icon-input-row {
   justify-content: space-between;
 
-  .category-icon {
+  .category-preview {
+    padding: 8px;
+    height: 64px;
+    width: 64px;
     /* Base CSS taken from Google's image search styling */
     background: #dcdcdc;
     background-image: linear-gradient(45deg,#efefef 25%,transparent 25%,transparent 75%,#efefef 75%,#efefef),linear-gradient(45deg,#efefef 25%,transparent 25%,transparent 75%,#efefef 75%,#efefef);

--- a/bosch-target-chart/app/views/categories/_form.html.haml
+++ b/bosch-target-chart/app/views/categories/_form.html.haml
@@ -21,7 +21,7 @@
         = f.file_field :icon, accept: 'image/jpeg,image/jpg,image/png,image/gif', id: 'iconInput', class: 'px-0'
         %small.form-text.text-muted
           = t(:categories)[:fields][:icon_help_text]
-      = image_tag category.icon.url, id: 'iconPreview', class: 'category-icon border rounded'
+      = image_tag category.icon.url, id: 'iconPreview', class: 'category-preview border rounded'
 .modal-footer
   %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }
     = t(:actions)[:close]


### PR DESCRIPTION
Issue #199 
---
There was a bug where if a large icon was uploaded, it would make the icon preview large as well (see issue for screenshot). Now, the icon size is fixed to the size of the preview window:
![image](https://user-images.githubusercontent.com/19152930/38840129-14269346-41ac-11e8-8c1d-1f0c763dae26.png)

![image](https://user-images.githubusercontent.com/19152930/38840120-0aae80d0-41ac-11e8-831f-a0a8eb8d5522.png)

All specs are passing:
![image](https://user-images.githubusercontent.com/19152930/38840149-25315504-41ac-11e8-94ba-765fd0c9b04f.png)

