### PR TITLE
KG - Chart Responsiveness Updates

### DIFF
--- a/bosch-target-chart/app/assets/stylesheets/charts.scss
+++ b/bosch-target-chart/app/assets/stylesheets/charts.scss
@@ -1,42 +1,110 @@
 .chart-header {
   font-weight: 200;
 
+  &:not(:first-child) {
+    @media(max-width:1199px) {
+      flex: 0 0 50%;
+      max-width: 50%;
+    }
+
+    @media(max-width:767px) {
+      flex: 0 0 100%;
+      max-width: 100%;
+    }
+
+    @media(min-width:1200px) {
+      flex: 0 0 60%;
+      max-width: 60%;
+    }
+  }
+
   @media(max-width:767px) {
     font-size: 2rem;
   }
 }
 
-.chart.droppable {
-  box-shadow: 0 0 $spacer rgba(0, 0, 0, 0.075) inset, 0 0 $spacer * 3 $theme_warning;
-}
-
-.chart-target {
-  @media(min-width:768px) {
-    flex: 0 0 20%;
-    max-width: 20%;
+.chart {
+  &.droppable {
+    box-shadow: 0 0 $spacer rgba(0, 0, 0, 0.075) inset, 0 0 $spacer * 3 $theme_warning;  
   }
 
-  @media(max-width:767px) {
-    flex: 0 0 50%;
-    max-width: 50%;
-  }
+  .category-row {
+    .category-header-container {
+      @media(min-width:768px) {
+        flex: 0 0 25%;
+        max-width: 25%;
+      }
 
-  .remove-chart-target {
-    text-decoration: none !important;
-    line-height: 50%;
+      @media(min-width:1200px) {
+        flex: 0 0 16.67%;
+        max-width: 16.67%;
+      }
 
-    &:focus {
-      outline: 1px dotted theme-color("muted");
+      @media(max-width:767px) {
+        flex: 0 0 100%;
+        max-width: 100%;
+      }
+    }
+
+    .chart-targets-container {
+      @media(min-width:768px) {
+        flex: 0 0 75%;
+        max-width: 75%;
+      }
+
+      @media(min-width:1200px) {
+        flex: 0 0 83.33%;
+        max-width: 83.33%;
+      }
+
+      @media(max-width:767px) {
+        flex: 0 0 100%;
+        max-width: 100%;
+      }
+ 
+      .chart-target {
+        @media(min-width:768px) {
+          flex: 0 0 33%;
+          max-width: 33%;
+        }
+
+        @media(min-width:1200px) {
+          flex: 0 0 20%;
+          max-width: 20%;
+        }
+
+        @media(max-width:767px) {
+          flex: 0 0 50%;
+          max-width: 50%;
+        }
+
+        .remove-chart-target {
+          text-decoration: none !important;
+          line-height: 50%;
+
+          &:focus {
+            outline: 1px dotted theme-color("muted");
+          }
+        }
+      }
     }
   }
 }
 
 #yearSelectContainer {
-  @media(min-width:768px) {
-    padding-right: 0;
+  @media(min-width:1200px) {
+    flex: 0 0 20%;
+    max-width: 20%;
+  }
+
+  @media(max-width:1199px) {
+    flex: 0 0 25%;
+    max-width: 25%;
   }
 
   @media(max-width:767px) {
+    flex: 0 0 100%;
+    max-width: 100%;
     padding: 0;
     margin-bottom: $spacer;
   }
@@ -47,19 +115,25 @@
 }
 
 #manageCategoriesContainer {
-  @media(min-width:768px) {
-    padding-right: 0;
+  @media(min-width:1200px) {
+    flex: 0 0 20%;
+    max-width: 20%;
+  }
+
+  @media(max-width:1199px) {
+    flex: 0 0 25%;
+    max-width: 25%;
   }
 
   @media(max-width:767px) {
-    padding: 0;
+    flex: 0 0 100%;
+    max-width: 100%;
+    padding: 0 !important;
     margin-bottom: $spacer * .5;
   }
 
   #manageCategories {
-    @media(max-width:767px) {
-      width: 100%;
-    }
+    width: 100%;
   }
 }
 

--- a/bosch-target-chart/app/views/charts/_chart.html.haml
+++ b/bosch-target-chart/app/views/charts/_chart.html.haml
@@ -2,17 +2,17 @@
   .container
     .row
       - if header_for == 'plant_chart' || header_for == 'show_department'
-        .col-md-2.order-md-last.d-flex.align-items-center.justify-content-end#manageCategoriesContainer
+        .order-md-last.d-flex.align-items-center.justify-content-end.pr-2#manageCategoriesContainer
           - if header_for == 'show_department'
             = link_to t(:departments)[:edit], edit_department_path(department.id, year: year), id: 'editDepartment', class: 'btn btn-block btn-warning float-right', remote: true
           - else
             = link_to t(:categories)[:manage_categories], categories_path, id: 'manageCategories', class: 'btn btn-block btn-info float-right', ondragstart: 'return false'
-        .col-md-2.order-md-last.d-flex.align-items-center.pr-0#yearSelectContainer
+        .order-md-last.d-flex.align-items-center.pr-0#yearSelectContainer
           - department ||= nil
           = render 'charts/year_dropdown', year: year, department: department
-        %h1.chart-header.col-md-8.pl-0.mb-0
+        %h1.chart-header.pl-0.mb-0
           = header
       - else
-        %h1.chart-header.col-md-12.pl-0.mb-0
+        %h1.chart-header.col-md-12.px-0.mb-0
           = link_to header, department_path(chart.department, year: year)
   = render 'charts/chart_body', chart: chart

--- a/bosch-target-chart/app/views/charts/_chart_body.html.haml
+++ b/bosch-target-chart/app/views/charts/_chart_body.html.haml
@@ -3,10 +3,10 @@
     .container
       - Category.all.each do |category|
         .row.category-row.pt-2.pl-2.align-items-start{ class: "category-#{category.id}", style: "background: #{category.color}" }
-          .category-header-container.col-md-2.d-flex.align-items-center.pl-0.pr-2.pb-2
+          .category-header-container.d-flex.align-items-center.pl-0.pr-2.pb-2
             = image_tag category.icon.url, class: 'category-icon'
             %h6.text-white.m-0
               = raw(category.name.gsub(" ", "<br>"))
-          .chart-targets-container.col-md-10.d-flex.flex-row.flex-wrap.p-0
+          .chart-targets-container.d-flex.flex-row.flex-wrap.p-0
             - chart.targets.where(category: category).eager_load(:indicators).each do |target|
               = render 'charts/chart_target', target: target, chart: chart


### PR DESCRIPTION
Issue #214

Fixes issues with tablets specifically not scaling nicely. This moves a lot of the column sizing to responsive css code to allow for more variability based on screen size.

### Tablet Horizontal (Before)
<img width="1043" alt="image" src="https://user-images.githubusercontent.com/12898988/39027254-13ca5066-441f-11e8-8b33-a02885534bc9.png">

### Tablet Horizontal (After)
<img width="1046" alt="image" src="https://user-images.githubusercontent.com/12898988/39027224-f81614e0-441e-11e8-8add-c70321e64f82.png">

### Tablet Vertical (Before)
<img width="779" alt="image" src="https://user-images.githubusercontent.com/12898988/39027241-0c118d58-441f-11e8-8e4e-80820410e21e.png">

### Tablet Vertical (After)
<img width="785" alt="image" src="https://user-images.githubusercontent.com/12898988/39027229-01a45490-441f-11e8-9152-21c94fb18a5b.png">

Mobile and computer screen sizes still work as intended.

### Specs
<img width="1916" alt="image" src="https://user-images.githubusercontent.com/12898988/39027140-84344c5e-441e-11e8-813a-6d1114f3b478.png">
