### PR TITLE
KG - Ignore Secrets.yml

### DIFF
--- a/bosch-target-chart/.gitignore
+++ b/bosch-target-chart/.gitignore
@@ -17,6 +17,9 @@
 # Ignore local database setup
 /config/database.yml
 
+# Ignore local secrets
+/config/secrets.yml
+
 # Ignore files uploaded to database
 /public/system/*
 

--- a/bosch-target-chart/config/secrets.yml.example
+++ b/bosch-target-chart/config/secrets.yml.example
@@ -27,6 +27,3 @@ test:
 # Instead, either read values from the environment.
 # Or, use `bin/rails secrets:setup` to configure encrypted secrets
 # and move the `production:` environment over there.
-
-production:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>


### PR DESCRIPTION
Add `config/secrets.yml` to `gitignore` so that secret keys can be hidden. These keys are used by Rails to validate authenticity tokens for requests to the server. It's important that they remain hidden.