### PR TITLE
KG - Add therubyracer Gem

### DIFF
--- a/bosch-target-chart/Gemfile
+++ b/bosch-target-chart/Gemfile
@@ -26,6 +26,7 @@ group :development, :test do
   gem 'faker' # Allow us to create fake data for tests
   gem 'pry-byebug' # Use pry and byebug commands for debugging
   gem 'rspec-rails' # Use the rspec test framework
+  gem 'therubyracer', platforms: :ruby
 end
 
 group :development do

--- a/bosch-target-chart/Gemfile.lock
+++ b/bosch-target-chart/Gemfile.lock
@@ -127,6 +127,7 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.6.0)
       launchy (~> 2.2)
+    libv8 (3.16.14.19)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -199,6 +200,7 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    ref (2.0.0)
     remotipart (1.4.0)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
@@ -252,6 +254,9 @@ GEM
     temple (0.8.0)
     terrapin (0.6.0)
       climate_control (>= 0.0.3, < 1.0)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
+      ref
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -305,6 +310,7 @@ DEPENDENCIES
   shoulda-matchers
   spring
   spring-watcher-listen (~> 2.0.0)
+  therubyracer
   turbolinks (~> 5)
   tzinfo-data
   uglifier


### PR DESCRIPTION
therubyracer is a runtime executable gem needed for some JavaScript libraries including Bootstrap in the Development environment. It's not needed for Production because we have Node.js.