### PR TITLE
SAW - Rule Reset on Target Update

### DIFF
--- a/bosch-target-chart/app/controllers/charts_controller.rb
+++ b/bosch-target-chart/app/controllers/charts_controller.rb
@@ -45,7 +45,7 @@ class ChartsController < ApplicationController
         unit: target.unit,
         unit_type: target.unit_type,
         compare_to_value: nil,
-        rule: nil,
+        rule: target.is_numerical? ? Target::DEFAULT_RULE : nil,
         comments: target.comments,
         year: @year
       )).save(validate: false)

--- a/bosch-target-chart/app/models/target.rb
+++ b/bosch-target-chart/app/models/target.rb
@@ -18,6 +18,8 @@ class Target < ApplicationRecord
     I18n.t(:targets)[:fields][:rule][:less_than_or_equal]
   ]
 
+  DEFAULT_RULE = RULES[1]
+
   validates :name, :department_id, :category_id, :unit, :unit_type, presence: true
   # Skip valiation if updating a different attribute
   validates :compare_to_value, presence: true,
@@ -36,7 +38,7 @@ class Target < ApplicationRecord
     joins(:indicators).distinct
   }
 
-  before_update :reset_compare_to_value, if: :unit_type_changed?
+  before_update :reset_compare_to_value_and_rule, if: :unit_type_changed?
   before_update :reset_indicator_values, if: :unit_type_changed?
 
   def is_numerical?
@@ -53,8 +55,9 @@ class Target < ApplicationRecord
 
   private
 
-  def reset_compare_to_value
+  def reset_compare_to_value_and_rule
     self.compare_to_value = nil if self.is_qualitative?
+    self.rule = self.is_qualitative? ? nil : DEFAULT_RULE
   end
 
   def reset_indicator_values

--- a/bosch-target-chart/spec/controllers/charts/post_create_spec.rb
+++ b/bosch-target-chart/spec/controllers/charts/post_create_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe ChartsController, type: :controller do
       @department_2 = FactoryBot.create(:department)
       @chart_pm     = FactoryBot.create(:chart, year: @year - 1)
       @chart_1      = FactoryBot.create(:chart, department: @department_1, year: @year - 1)
-      @target_1     = FactoryBot.create(:target, department: @department_1, year: @year - 1)
-      @target_2     = FactoryBot.create(:target, department: @department_2, year: @year - 1)
+      @target_1     = FactoryBot.create(:target, :numerical, department: @department_1, year: @year - 1)
+      @target_2     = FactoryBot.create(:target, :qualitative, department: @department_2, year: @year - 1)
       @indicator_1  = FactoryBot.create(:indicator, target: @target_1)
       @indicator_2  = FactoryBot.create(:indicator, target: @target_2)
 
@@ -49,6 +49,14 @@ RSpec.describe ChartsController, type: :controller do
 
     it 'should clone ChartsTargets' do
       expect(Target.for_year(@year).map(&:charts).flatten.uniq.count).to eq(2)
+    end
+
+    it 'should reset numerical target rules to the default rule' do
+      expect(Target.where(year: @year, unit_type: Target::UNIT_TYPES[0]).first.rule).to eq(Target::DEFAULT_RULE)
+    end
+
+    it 'should reset qualitative target rules to nil' do
+      expect(Target.where(year: @year, unit_type: Target::UNIT_TYPES[1]).first.rule).to eq(nil)
     end
   end
 end

--- a/bosch-target-chart/spec/models/target_spec.rb
+++ b/bosch-target-chart/spec/models/target_spec.rb
@@ -100,6 +100,20 @@ RSpec.describe Target, type: :model do
 
         expect(t.reload.compare_to_value).to eq(nil)
       end
+
+      it 'should reset rule when target is qualitative' do
+        t = FactoryBot.create(:target, :numerical, rule: Target::RULES[0])
+        t.update_attribute(:unit_type, Target::UNIT_TYPES[1])
+
+        expect(t.reload.rule).to eq(nil)
+      end
+
+      it 'should set default rule when target is numerical' do
+        t = FactoryBot.create(:target, :qualitative, rule: nil)
+        t.update_attribute(:unit_type, Target::UNIT_TYPES[0])
+
+        expect(t.reload.rule).to eq(Target::DEFAULT_RULE)
+      end
     end
 
     describe '#reset_indicator_values' do


### PR DESCRIPTION
Issue #181 
---
When a Target's unit type is changed from numerical to qualitative, the rule is set to nil.
When a Target's unit type is changed from qualitative to numerical, the rule is set to less than or equal to (the default rule). Originally we were just going to set this as nil, but I found that a nil rule behaves the same way as ≤ on indicators, so rather than implementing a nil rule for indicators, I made it default to ≤ when changing the unit type. That way, the user can see that their rule is ≤ and can change it if they want a different rule.

All specs passing:
![image](https://user-images.githubusercontent.com/19152930/39225097-7097f9e0-4818-11e8-9dfd-bbc822300432.png)
